### PR TITLE
Fix success check in TestAccessAsync

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/AI/OrchestratorMethods.CallOpenAI.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/AI/OrchestratorMethods.CallOpenAI.cs
@@ -39,7 +39,7 @@ namespace RFPResponsePOC.AI
 
             var json = ExtractJsonFromResponse(reply);
 
-            return json != null;
+            return !string.IsNullOrWhiteSpace(json);
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- ensure `TestAccessAsync` returns `false` when the reply has no JSON

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6878165c4f8883339ea8209e9ff620f2