### PR TITLE
Fix comment in DatabaseService

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Services/DatabaseService.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Services/DatabaseService.cs
@@ -29,7 +29,7 @@ namespace RFPResponsePOC.Model
 
             if (RFPResponsePOCDatabase == null)
             {
-                // Create a new instance of the SettingsService
+                // Create a new Database instance
                 RFPResponsePOCDatabase = new Database();
 
                 RFPResponsePOCDatabase.colRFPResponsePOCDatabase = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary
- clarify creation of `Database` object in comment

## Testing
- `dotnet build RFPPOC.sln -c Release` *(fails: .NET SDK 8.0 does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687818ba68148333b1fc89c6d459a01a