### PR TITLE
Fix typo in comment and rename variable

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Home.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Home.razor
@@ -250,17 +250,17 @@
         int intVersionNumber = 0;
         string strVersion = strParamVersion;
 
-        // Split into parts seperated by periods
+        // Split into parts separated by periods
         char[] splitchar = { '.' };
         var strSegments = strVersion.Split(splitchar);
 
         // Process the segments
         int i = 0;
-        List<int> colMultiplyers = new List<int> { 10000, 100, 1 };
+        List<int> colMultipliers = new List<int> { 10000, 100, 1 };
         foreach (var strSegment in strSegments)
         {
             int intSegmentNumber = Convert.ToInt32(strSegment);
-            intVersionNumber = intVersionNumber + (intSegmentNumber * colMultiplyers[i]);
+            intVersionNumber = intVersionNumber + (intSegmentNumber * colMultipliers[i]);
             i++;
         }
 


### PR DESCRIPTION
## Summary
- fix 'separated' spelling in comment
- rename `colMultiplyers` to `colMultipliers`

## Testing
- `dotnet build RFPResponsePOC/RFPResponsePOC.Client/RFPResponsePOC.Client.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6878187f5b08833387376523d8113d0e