### PR TITLE
Display capacity results in a table

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Models/CapacityModels.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Models/CapacityModels.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace RFPResponsePOC.Models
+{
+    public class CapacityRoot
+    {
+        [JsonProperty("rooms")] public List<Room> Rooms { get; set; }
+    }
+
+    public class Room
+    {
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("squareFeet")] public int SquareFeet { get; set; }
+        [JsonProperty("capacities")] public Capacities Capacities { get; set; }
+    }
+
+    public class Capacities
+    {
+        [JsonProperty("banquet")] public int Banquet { get; set; }
+        [JsonProperty("conference")] public int Conference { get; set; }
+        [JsonProperty("square")] public int Square { get; set; }
+        [JsonProperty("reception")] public int Reception { get; set; }
+        [JsonProperty("schoolRoom")] public int SchoolRoom { get; set; }
+        [JsonProperty("theatre")] public int Theatre { get; set; }
+        [JsonProperty("uShape")] public int UShape { get; set; }
+    }
+}

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -2,6 +2,8 @@
 @using System.Text
 @using RFPResponsePOC.Client.Services
 @using RFPResponsePOC.Model
+@using RFPResponsePOC.Models
+@using Newtonsoft.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using RFPResponsePOC.AI
 @inject NotificationService NotificationService
@@ -38,13 +40,66 @@
     </div>
 }
 <br />
-<p>
-    @if (@result.Response != "")
-    {
-        <!-- Display the result of the AI response in a scrollable text box -->
-        <RadzenTextArea Rows="10" Style="width: 100%;" @bind-Value="@result.Response" ReadOnly="true" />
-    }
-</p>
+@if (capacityData?.Rooms != null)
+{
+    <RadzenDataGrid @ref="grid" Data="@capacityData.Rooms" TItem="Room" EditMode="DataGridEditMode.Popup" AllowPaging="false">
+        <Columns>
+            <RadzenDataGridColumn TItem="Room" Property="Name" Title="Name" />
+            <RadzenDataGridColumn TItem="Room" Property="SquareFeet" Title="Sq Ft" />
+            <RadzenDataGridColumn TItem="Room" Title="Banquet">
+                <Template Context="r">@r.Capacities.Banquet</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.Banquet" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="Conference">
+                <Template Context="r">@r.Capacities.Conference</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.Conference" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="Square">
+                <Template Context="r">@r.Capacities.Square</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.Square" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="Reception">
+                <Template Context="r">@r.Capacities.Reception</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.Reception" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="School Room">
+                <Template Context="r">@r.Capacities.SchoolRoom</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.SchoolRoom" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="Theatre">
+                <Template Context="r">@r.Capacities.Theatre</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.Theatre" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="U-Shape">
+                <Template Context="r">@r.Capacities.UShape</Template>
+                <EditTemplate Context="r">
+                    <RadzenNumeric TValue="int" Style="width:100%" @bind-Value="r.Capacities.UShape" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="Room" Title="Edit" Context="r">
+                <Template Context="r">
+                    <RadzenButton Icon="edit" Size="ButtonSize.Small" Click="@(() => grid.EditRow(r))" />
+                </Template>
+                <EditTemplate Context="r">
+                    <RadzenButton Icon="save" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Primary" Click="@(() => SaveRow(r))" />
+                    <RadzenButton Icon="close" Size="ButtonSize.Small" ButtonStyle="ButtonStyle.Light" Click="@(() => grid.CancelEditRow(r))" Style="margin-left:10px" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+}
 
 @code {
 #nullable disable
@@ -55,8 +110,11 @@
 
     // Reference to the RadzenUpload component
     Radzen.Blazor.RadzenUpload uploader;
+    Radzen.Blazor.RadzenDataGrid<Room> grid;
 
     AIResponse result = new AIResponse();
+
+    CapacityRoot capacityData;
 
     ZipService objZipService = new ZipService();
 
@@ -156,6 +214,9 @@
             // Call the OpenAIChatAsync method with the settings, prompt, and OCR result
             result = await objOrchestratorMethods.CallOpenAIAsync(settingsService, Capcityprompt);
 
+            // Parse the JSON into objects for display
+            capacityData = JsonConvert.DeserializeObject<CapacityRoot>(result.Response);
+
             InProgress = false;
             StateHasChanged();
 
@@ -197,6 +258,11 @@
                 Duration = 8000
             });
         }
+    }
+
+    void SaveRow(Room room)
+    {
+        grid.UpdateRow(room);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- convert OCR capacity JSON into typed models
- show the parsed room data in a Radzen grid with popup editing

## Testing
- `dotnet build RFPPOC.sln` *(fails: NETSDK1045 current SDK doesn't support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687aef57fd2c8333823fee6dfb73a7fd