### PR TITLE
Save capacity chart result

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -1,6 +1,7 @@
 ﻿@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @using System.Text
 @using RFPResponsePOC.Client.Services
+@using System.IO
 @using RFPResponsePOC.Model
 @using RFPResponsePOC.Models
 @using Newtonsoft.Json
@@ -216,6 +217,10 @@
 
             // Parse the JSON into objects for display
             capacityData = JsonConvert.DeserializeObject<CapacityRoot>(result.Response);
+
+            // Save the JSON result to the RFPResponsePOC folder
+            var capacityFilePath = @"/RFPResponsePOC/Capacity.json";
+            await File.WriteAllTextAsync(capacityFilePath, result.Response);
 
             InProgress = false;
             StateHasChanged();


### PR DESCRIPTION
## Summary
- allow Capacity chart upload to save OpenAI output to `/RFPResponsePOC/Capacity.json`

## Testing
- `dotnet build RFPPOC.sln -c Release` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68865df549a0833388226422da144572