### PR TITLE
Handle room edits and refresh grid

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -47,7 +47,7 @@
         <Columns>
             <RadzenDataGridColumn TItem="Room" Title="Edit" Context="r" Resizable="false" Width="50px">
                 <Template Context="r">
-                    <RadzenButton Icon="edit" Size="ButtonSize.Small" Click="@(() => OpenEditDialog(r))" />
+                    <RadzenButton Icon="edit" Size="ButtonSize.Small" Click="@(async () => await OpenEditDialog(r))" />
                 </Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn TItem="Room" Property="Name" Title="Name" Resizable="true" Width="200px" Sortable="true" />
@@ -309,7 +309,7 @@
 
     private Room selectedRoom;
 
-    private void OpenEditDialog(Room room)
+    private async Task OpenEditDialog(Room room)
     {
         selectedRoom = room;
 
@@ -317,14 +317,21 @@
         Console.WriteLine($"Opening dialog for room: {room?.Name}");
         Console.WriteLine($"Total rooms available: {capacityData?.Rooms?.Count ?? 0}");
 
-        DialogService.Open<EditRoomDialog>(
+        var result = await DialogService.OpenAsync<EditRoomDialog>(
             "Edit Room",
-            new Dictionary<string, object> { 
-                { "Room", selectedRoom }, 
-                { "AllRooms", capacityData?.Rooms ?? new List<Room>() } 
+            new Dictionary<string, object> {
+                { "Room", selectedRoom },
+                { "AllRooms", capacityData?.Rooms ?? new List<Room>() }
             },
             new DialogOptions { Width = "600px", Height = "700px" }
         );
+
+        if (result is Room updatedRoom)
+        {
+            SaveRoom(updatedRoom);
+            await grid.Reload();
+            StateHasChanged();
+        }
     }
 
     private void SaveRoom(Room room)

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditRoomDialog.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditRoomDialog.razor
@@ -114,7 +114,7 @@
     </RadzenTabs>
 
     <div style="margin-top: 20px;">
-        <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" Click="Save" />
+        <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" ButtonType="ButtonType.Submit" />
         <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click="Cancel" />
     </div>
 </EditForm>
@@ -145,11 +145,6 @@
     }
 
     private void HandleValidSubmit()
-    {
-        DialogService.Close(Room);
-    }
-
-    private void Save()
     {
         DialogService.Close(Room);
     }


### PR DESCRIPTION
## Summary
- Allow Capacity page to await EditRoomDialog and persist changes via existing SaveRoom helper.
- Refresh room data grid after edits and wire dialog Save button to submit form.

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688d74888958833397a0f4331634d11f