### PR TITLE
Add room deletion with confirmation dialog

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Models/EditRoomDialogResult.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Models/EditRoomDialogResult.cs
@@ -1,0 +1,10 @@
+using RFPResponsePOC.Models;
+
+namespace RFPResponsePOC.Client.Models
+{
+    public class EditRoomDialogResult
+    {
+        public bool IsDeleted { get; set; }
+        public Room Room { get; set; }
+    }
+}

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -326,9 +326,16 @@
             new DialogOptions { Width = "600px", Height = "700px" }
         );
 
-        if (result is Room updatedRoom)
+        if (result is EditRoomDialogResult dialogResult)
         {
-            SaveRoom(updatedRoom);
+            if (dialogResult.IsDeleted)
+            {
+                DeleteRoom(dialogResult.Room);
+            }
+            else
+            {
+                SaveRoom(dialogResult.Room);
+            }
             await grid.Reload();
             StateHasChanged();
         }
@@ -342,6 +349,24 @@
         if (index >= 0)
         {
             capacityData.Rooms[index] = room;
+        }
+
+        // Save changes to the JSON file
+        Task.Run(async () =>
+        {
+            var json = JsonConvert.SerializeObject(capacityData, Formatting.Indented);
+            await File.WriteAllTextAsync($"{BasePath}//Capacity.json", json);
+        });
+    }
+
+    private void DeleteRoom(Room room)
+    {
+        // Remove the room from the data source
+        var index = capacityData.Rooms.FindIndex(r => r.Name == room.Name);
+
+        if (index >= 0)
+        {
+            capacityData.Rooms.RemoveAt(index);
         }
 
         // Save changes to the JSON file

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditRoomDialog.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditRoomDialog.razor
@@ -1,4 +1,5 @@
 @using RFPResponsePOC.Models
+@using RFPResponsePOC.Client.Models
 
 @inject DialogService DialogService
 
@@ -115,6 +116,7 @@
 
     <div style="margin-top: 20px;">
         <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" ButtonType="ButtonType.Submit" />
+        <RadzenButton Text="Delete" ButtonStyle="ButtonStyle.Danger" Click="ConfirmDelete" />
         <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click="Cancel" />
     </div>
 </EditForm>
@@ -146,7 +148,16 @@
 
     private void HandleValidSubmit()
     {
-        DialogService.Close(Room);
+        DialogService.Close(new EditRoomDialogResult { IsDeleted = false, Room = Room });
+    }
+
+    private async Task ConfirmDelete()
+    {
+        var confirm = await DialogService.Confirm("Are you sure you want to delete this room?", "Confirm Delete");
+        if (confirm == true)
+        {
+            DialogService.Close(new EditRoomDialogResult { IsDeleted = true, Room = Room });
+        }
     }
 
     private void Cancel()


### PR DESCRIPTION
## Summary
- add delete button to EditRoom dialog with confirmation
- handle dialog result to remove rooms from capacity list
- create result model to signal save vs delete

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688dfe1c7f2483339b803b0604af970b