### PR TITLE
Add PDF export for capacity chart

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -46,7 +46,8 @@
 @if (capacityData?.Rooms != null)
 {
     <RadzenButton Text="Add Room" Icon="add" Style="margin-bottom: 10px; background-color: green;" ButtonStyle="ButtonStyle.Primary" Click="OpenAddRoomDialog" />
-    <RadzenDataGrid @ref="grid" Data="@ParentRooms" TItem="Room" EditMode="DataGridEditMode.Single" AllowPaging="false" AllowColumnResize="true" ExpandMode="DataGridExpandMode.Single" RowRender="@RowRender" RowExpand="@LoadChildRooms">
+    <RadzenButton Text="Print Chart" Icon="picture_as_pdf" Style="margin-left: 10px; margin-bottom: 10px;" ButtonStyle="ButtonStyle.Secondary" Click="PrintCapacityChart" />
+    <RadzenDataGrid id="capacityGrid" @ref="grid" Data="@ParentRooms" TItem="Room" EditMode="DataGridEditMode.Single" AllowPaging="false" AllowColumnResize="true" ExpandMode="DataGridExpandMode.Single" RowRender="@RowRender" RowExpand="@LoadChildRooms">
         <Template Context="group">
             <RadzenDataGrid Data="@GetChildRooms(group)" TItem="Room" AllowPaging="false" AllowColumnResize="true">
                 <Columns>
@@ -126,6 +127,11 @@
     void LoadChildRooms(Room room)
     {
         childRooms[room.Name] = capacityData?.Rooms?.Where(r => r.RoomGroup == room.Name).ToList();
+    }
+
+    private async Task PrintCapacityChart()
+    {
+        await JsRuntime.InvokeVoidAsync("pdfInterop.exportElementToPdf", "capacityGrid");
     }
 
     private bool InProgress = false;

--- a/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
+++ b/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
@@ -42,5 +42,29 @@ window.pdfInterop = {
         const canvas = document.getElementById(canvasId);
         if (!canvas) return null;
         return canvas.toDataURL('image/png');
+    },
+    exportElementToPdf: async function(elementId) {
+        const element = document.getElementById(elementId);
+        if (!element) return;
+
+        if (!window.html2canvas) {
+            const html2canvasModule = await import('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js');
+            window.html2canvas = html2canvasModule.default;
+        }
+
+        if (!window.jsPDF) {
+            const jsPDFModule = await import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
+            window.jsPDF = jsPDFModule.jsPDF;
+        }
+
+        const canvas = await window.html2canvas(element);
+        const imgData = canvas.toDataURL('image/png');
+        const pdf = new window.jsPDF({
+            orientation: 'landscape',
+            unit: 'pt',
+            format: [canvas.width, canvas.height]
+        });
+        pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+        pdf.save('capacity-chart.pdf');
     }
 };


### PR DESCRIPTION
## Summary
- add PDF export helper in pdfInterop.js using html2canvas and jsPDF
- add print button on Capacity page to export the capacity grid as PDF

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688e971c85e08333ba2b9f5aa6c6eaef