### PR TITLE
Add ability to export parent rooms to PDF

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -131,7 +131,7 @@
 
     private async Task PrintCapacityChart()
     {
-        await JsRuntime.InvokeVoidAsync("pdfInterop.exportElementToPdf", "capacityGrid");
+        await JsRuntime.InvokeVoidAsync("pdfInterop.exportRoomsToPdf", ParentRooms);
     }
 
     private bool InProgress = false;

--- a/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
+++ b/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
@@ -85,5 +85,68 @@ window.pdfInterop = {
         } catch (error) {
             console.error("Error generating PDF:", error);
         }
+    },
+    exportRoomsToPdf: function (rooms) {
+        if (!rooms || rooms.length === 0) {
+            console.error("No rooms provided for PDF export.");
+            return;
+        }
+
+        if (!window.jsPDF) {
+            if (window.jspdf && window.jspdf.jsPDF) {
+                window.jsPDF = window.jspdf.jsPDF;
+            } else {
+                console.error("jsPDF is not loaded. Ensure the library is included.");
+                return;
+            }
+        }
+
+        const doc = new window.jsPDF();
+        const lineHeight = 10;
+        let y = 10;
+
+        rooms.forEach(room => {
+            const name = room.name || room.Name || "";
+            const squareFeet = room.squareFeet ?? room.SquareFeet ?? "";
+            const length = room.length ?? room.Length ?? "";
+            const width = room.width ?? room.Width ?? "";
+            const ceiling = room.ceilingHeight ?? room.CeilingHeight ?? "";
+            const floor = room.floorLevel ?? room.FloorLevel ?? "";
+            const natural = (room.hasNaturalLight ?? room.HasNaturalLight) ? "Yes" : "No";
+            const pillars = (room.hasPillars ?? room.HasPillars) ? "Yes" : "No";
+
+            const capacities = room.capacities || room.Capacities || {};
+            const banquet = capacities.banquet ?? capacities.Banquet ?? 0;
+            const conference = capacities.conference ?? capacities.Conference ?? 0;
+            const square = capacities.square ?? capacities.Square ?? 0;
+            const reception = capacities.reception ?? capacities.Reception ?? 0;
+            const schoolRoom = capacities.schoolRoom ?? capacities.SchoolRoom ?? 0;
+            const theatre = capacities.theatre ?? capacities.Theatre ?? 0;
+            const uShape = capacities.uShape ?? capacities.UShape ?? 0;
+            const hollowSquare = capacities.hollowSquare ?? capacities.HollowSquare ?? 0;
+            const boardroom = capacities.boardroom ?? capacities.Boardroom ?? 0;
+            const crescentRounds = capacities.crescentRounds ?? capacities.CrescentRounds ?? 0;
+
+            const headerLines = doc.splitTextToSize(`Name: ${name}`, 180);
+            doc.text(headerLines, 10, y);
+            y += headerLines.length * lineHeight;
+
+            const detailText = `Square Feet: ${squareFeet} Length: ${length} Width: ${width} Ceiling Height: ${ceiling} Floor Level: ${floor} Natural Light: ${natural} Has Pillars: ${pillars}`;
+            const detailLines = doc.splitTextToSize(detailText, 180);
+            doc.text(detailLines, 10, y);
+            y += detailLines.length * lineHeight;
+
+            const capacityText = `Banquet: ${banquet} Conference: ${conference} Square: ${square} Reception: ${reception} School Room: ${schoolRoom} Theatre: ${theatre} U-Shape: ${uShape} Hollow Square: ${hollowSquare} Boardroom: ${boardroom} Crescent Rounds: ${crescentRounds}`;
+            const capacityLines = doc.splitTextToSize(capacityText, 180);
+            doc.text(capacityLines, 10, y);
+            y += capacityLines.length * lineHeight + lineHeight;
+
+            if (y > 280) {
+                doc.addPage();
+                y = 10;
+            }
+        });
+
+        doc.save('parent-rooms.pdf');
     }
 };


### PR DESCRIPTION
## Summary
- Generate `parent-rooms.pdf` containing the ParentRooms data
- Wire the Capacity page's print button to the new PDF export

## Testing
- `dotnet test` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688e9ed83d0c8333b0433fd0229360a3