### PR TITLE
Add proposal template editor

### DIFF
--- a/RFPResponsePOC/DefaultTemplate.txt
+++ b/RFPResponsePOC/DefaultTemplate.txt
@@ -1,0 +1,31 @@
+Subject: RFP Response – [EVENT_NAME] at [VENUE_NAME]
+
+Dear [REQUESTOR_NAME],
+
+Thank you for considering [VENUE_NAME] for your upcoming event, [EVENT_NAME], scheduled for [EVENT_DATES]. We appreciate the opportunity to respond to your Request for Proposal.
+
+We have carefully reviewed your proposed agenda and requirements. Based on our current availability and capabilities, we are pleased to present the following:
+
+**Proposed Agenda**
+[PROPOSED_AGENDA]
+
+**Suggested Substitutions**
+The following agenda items have been revised to better align with our venue’s layout, capacity, and services. We believe these alternatives will still meet your event objectives:
+
+[SUBSTITUTION_AGENDA_ITEMS]
+
+**Items We Are Unable to Accommodate**
+Regrettably, the following items cannot be supported at our venue due to logistical or operational constraints:
+
+[UNABLE_TO_ACCOMMODATE_AGENDA_ITEMS]
+
+We remain committed to providing you with a seamless and successful event experience and are happy to collaborate further to refine the agenda or explore additional solutions.
+
+Please let us know a convenient time to discuss the proposal in more detail or if any clarification is needed.
+
+Warm regards,  
+[VENUE_CONTACT_NAME]  
+[VENUE_CONTACT_TITLE]  
+[VENUE_NAME]  
+[VENUE_PHONE_NUMBER]  
+[VENUE_EMAIL_ADDRESS]  

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditTemplate.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/EditTemplate.razor
@@ -1,0 +1,52 @@
+@using System.IO
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+<RadzenTextArea @bind-Value="templateContent" Rows="20" Style="width:100%; min-height:400px;" />
+<div style="margin-top:10px;">
+    <RadzenButton Text="Save" Style="background-color: green;" ButtonStyle="ButtonStyle.Primary" Click="SaveTemplate" />
+    <RadzenButton Text="Cancel" Style="margin-left:10px;" ButtonStyle="ButtonStyle.Light" Click="Cancel" />
+</div>
+
+@code {
+    string BasePath = @"/RFPResponsePOC";
+    string templateContent;
+    string TemplateFile => $"{BasePath}/Template.txt";
+    string DefaultTemplateFile => $"{BasePath}/DefaultTemplate.txt";
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!Directory.Exists(BasePath))
+        {
+            Directory.CreateDirectory(BasePath);
+        }
+
+        if (!File.Exists(TemplateFile))
+        {
+            var defaultContent = File.Exists(DefaultTemplateFile)
+                ? await File.ReadAllTextAsync(DefaultTemplateFile)
+                : string.Empty;
+            await File.WriteAllTextAsync(TemplateFile, defaultContent);
+        }
+
+        templateContent = await File.ReadAllTextAsync(TemplateFile);
+    }
+
+    private async Task SaveTemplate()
+    {
+        await File.WriteAllTextAsync(TemplateFile, templateContent);
+        NotificationService.Notify(new NotificationMessage
+        {
+            Severity = NotificationSeverity.Success,
+            Summary = "Saved",
+            Detail = "Template updated",
+            Duration = 4000
+        });
+        DialogService.Close(true);
+    }
+
+    private void Cancel()
+    {
+        DialogService.Close(false);
+    }
+}

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
@@ -1,5 +1,6 @@
 ﻿@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @using System.Text
+@using System.Collections.Generic
 @using RFPResponsePOC.Client.Services
 @using RFPResponsePOC.Model
 @using Microsoft.AspNetCore.Components.Forms
@@ -8,14 +9,12 @@
 @inject DialogService DialogService
 @inject IJSRuntime JsRuntime
 @inject LogService LogService
-@inject NotificationService NotificationService
-@inject DialogService DialogService
 @inject Blazored.LocalStorage.ILocalStorageService localStorage
 @inject SettingsService _SettingsService
 @inject NavigationManager Navigation
-@inject IJSRuntime JsRuntime
 @inject HttpClient Http
 <h3>Proposal</h3>
+<RadzenButton Text="Edit Template" Icon="edit" Style="background-color: green; margin-top:10px;" ButtonStyle="ButtonStyle.Primary" Click="EditTemplate" />
 <br />
 <br />
 <h4>Coming Soon</h4>
@@ -49,6 +48,14 @@
             // Initialize the ZipService
             objZipService = new ZipService(JsRuntime, localStorage, _SettingsService, LogService);
         }
+    }
+
+    async Task EditTemplate(MouseEventArgs args)
+    {
+        await DialogService.OpenAsync<EditTemplate>(
+            "Edit Template",
+            new Dictionary<string, object>(),
+            new DialogOptions { Width = "700px", Height = "600px" });
     }
 
     #region JavaScript


### PR DESCRIPTION
## Summary
- use `DefaultTemplate.txt` as fallback when no user template exists
- rework template editing into a dialog with save and cancel actions
- open the dialog from the Proposal page instead of navigating away

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68924ca5aff08333b965080d6e0c15e4