### PR TITLE
Add CSV download for capacity chart rooms

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Capacity.razor
@@ -50,6 +50,7 @@
     @if (ParentRooms.Count() >= 1)
     {
         <RadzenButton Text="Print Chart" Icon="picture_as_pdf" Style="margin-left: 10px; margin-bottom: 10px;" ButtonStyle="ButtonStyle.Secondary" Click="PrintCapacityChart" />
+        <RadzenButton Text="Download CSV" Icon="download" Style="margin-left: 10px; margin-bottom: 10px;" ButtonStyle="ButtonStyle.Secondary" Click="DownloadCapacityCsv" />
     }
     <RadzenDataGrid id="capacityGrid" @ref="grid" Data="@ParentRooms" TItem="Room" EditMode="DataGridEditMode.Single" AllowPaging="false" AllowColumnResize="true" ExpandMode="DataGridExpandMode.Single" RowRender="@RowRender" RowExpand="@LoadChildRooms">
         <Template Context="group">
@@ -136,6 +137,11 @@
     private async Task PrintCapacityChart()
     {
         await JsRuntime.InvokeVoidAsync("pdfInterop.exportRoomsToPdf", capacityData?.Rooms);
+    }
+
+    private async Task DownloadCapacityCsv()
+    {
+        await JsRuntime.InvokeVoidAsync("pdfInterop.downloadRoomsCsv", capacityData?.Rooms);
     }
 
     private bool InProgress = false;

--- a/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
+++ b/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
@@ -149,4 +149,54 @@ window.pdfInterop = {
 
         doc.save('parent-rooms.pdf');
     }
+    ,
+    downloadRoomsCsv: function (rooms) {
+        if (!rooms || rooms.length === 0) {
+            console.error("No rooms provided for CSV export.");
+            return;
+        }
+
+        const headers = [
+            'Name','SquareFeet','Length','Width','CeilingHeight','FloorLevel','NaturalLight','HasPillars',
+            'Banquet','Conference','Square','Reception','SchoolRoom','Theatre','UShape','HollowSquare','Boardroom','CrescentRounds'
+        ];
+
+        const rows = [headers.join(',')];
+
+        rooms.forEach(room => {
+            const capacities = room.capacities || room.Capacities || {};
+            const row = [
+                room.name || room.Name || '',
+                room.squareFeet ?? room.SquareFeet ?? '',
+                room.length ?? room.Length ?? '',
+                room.width ?? room.Width ?? '',
+                room.ceilingHeight ?? room.CeilingHeight ?? '',
+                room.floorLevel ?? room.FloorLevel ?? '',
+                (room.hasNaturalLight ?? room.HasNaturalLight) ? 'Yes' : 'No',
+                (room.hasPillars ?? room.HasPillars) ? 'Yes' : 'No',
+                capacities.banquet ?? capacities.Banquet ?? 0,
+                capacities.conference ?? capacities.Conference ?? 0,
+                capacities.square ?? capacities.Square ?? 0,
+                capacities.reception ?? capacities.Reception ?? 0,
+                capacities.schoolRoom ?? capacities.SchoolRoom ?? 0,
+                capacities.theatre ?? capacities.Theatre ?? 0,
+                capacities.uShape ?? capacities.UShape ?? 0,
+                capacities.hollowSquare ?? capacities.HollowSquare ?? 0,
+                capacities.boardroom ?? capacities.Boardroom ?? 0,
+                capacities.crescentRounds ?? capacities.CrescentRounds ?? 0
+            ];
+            rows.push(row.join(','));
+        });
+
+        const csvContent = rows.join('\n');
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+        const link = document.createElement('a');
+        const url = URL.createObjectURL(blob);
+        link.setAttribute('href', url);
+        link.setAttribute('download', 'rooms.csv');
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
 };


### PR DESCRIPTION
## Summary
- Add download button to Capacity page allowing CSV export of room data
- Implement JS helper to build CSV and trigger file download

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68934f6ccfec83339cbf544689236f31