### PR TITLE
Switch log download to text format

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Logs.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Logs.razor
@@ -110,13 +110,13 @@
                 return;
             }
 
-            // Create CSV content
-            var csvContent = string.Join("\n", RFPResponsePOCLog);
-            var bytes = Encoding.UTF8.GetBytes(csvContent);
+            // Create text content with double line breaks
+            var textContent = string.Join("\n\n", RFPResponsePOCLog) + "\n\n";
+            var bytes = Encoding.UTF8.GetBytes(textContent);
             var base64String = Convert.ToBase64String(bytes);
 
             // Generate filename with timestamp
-            var fileName = $"RFPResponsePOC_Log_{DateTime.Now:yyyyMMdd_HHmmss}.csv";
+            var fileName = $"RFPResponsePOC_Log_{DateTime.Now:yyyyMMdd_HHmmss}.txt";
 
             // Use JavaScript to download the file
             await JsRuntime.InvokeVoidAsync("eval", $@"
@@ -126,7 +126,7 @@
                     byteNumbers[i] = bytes.charCodeAt(i);
                 }}
                 const byteArray = new Uint8Array(byteNumbers);
-                const blob = new Blob([byteArray], {{ type: 'text/csv;charset=utf-8;' }});
+                const blob = new Blob([byteArray], {{ type: 'text/plain;charset=utf-8;' }});
                 const link = document.createElement('a');
                 const url = URL.createObjectURL(blob);
                 link.setAttribute('href', url);


### PR DESCRIPTION
## Summary
- download logs as .txt instead of .csv
- separate log entries with double line breaks

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68991627c0d88333ac1d510be6a2ea3c