### PR TITLE
Enable adding and deleting proposal rows

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
@@ -57,6 +57,7 @@
 
 @if (proposalRows?.Any() == true)
 {
+    <RadzenButton Text="Add Row" Icon="add" Style="margin-top:10px" ButtonStyle="ButtonStyle.Primary" Click="InsertRow" />
     <RadzenDataGrid @ref="grid" Data="@proposalRows" TItem="ProposalRow" EditMode="DataGridEditMode.Single" Editable="true" Style="margin-top:20px">
         <Columns>
             <RadzenDataGridColumn TItem="ProposalRow" Filterable="false" Sortable="false" Width="80px" TextAlign="TextAlign.Center" Title="EDIT">
@@ -73,6 +74,14 @@
                                       Click="@((args) => EditRow(row))" @onclick:stopPropagation="true"
                                       title="Edit row" />
                     }
+                </Template>
+            </RadzenDataGridColumn>
+
+            <RadzenDataGridColumn TItem="ProposalRow" Filterable="false" Sortable="false" Width="80px" TextAlign="TextAlign.Center" Title="DELETE">
+                <Template Context="row">
+                    <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.ExtraSmall"
+                                  Click="@((args) => DeleteRow(row))" @onclick:stopPropagation="true"
+                                  title="Delete row" />
                 </Template>
             </RadzenDataGridColumn>
 
@@ -219,6 +228,27 @@
     async Task EditRow(ProposalRow row)
     {
         await grid.EditRow(row);
+    }
+
+    ProposalRow newRow;
+    void InsertRow()
+    {
+        newRow = new ProposalRow
+        {
+            StartDate = DateTime.Today,
+            EndDate = DateTime.Today
+        };
+        proposalRows.Add(newRow);
+        grid.EditRow(newRow);
+    }
+
+    async Task DeleteRow(ProposalRow row)
+    {
+        if (proposalRows.Contains(row))
+        {
+            proposalRows.Remove(row);
+            await grid.Reload();
+        }
     }
 
     async Task SaveRow(ProposalRow row)


### PR DESCRIPTION
## Summary
- add Add Row button for proposals
- allow deleting proposal rows

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689be9ee77988333ba5bb896594b196e