### PR TITLE
Use dropdown for Room Type in Proposal page

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Proposal.razor
@@ -149,7 +149,7 @@
             <RadzenDataGridColumn TItem="ProposalRow" Property="RoomType" Title="Room Type" Width="120px">
                 <Template Context="row">@row.RoomType</Template>
                 <EditTemplate Context="row">
-                    <RadzenTextBox @bind-Value="row.RoomType" Style="width:100%" />
+                    <RadzenDropDown Data="@roomTypeOptions" @bind-Value="row.RoomType" Style="width:100%" />
                 </EditTemplate>
             </RadzenDataGridColumn>
 
@@ -196,6 +196,18 @@
 
     private List<ProposalRow> proposalRows = new();
     private List<string> roomOptions = new();
+    private readonly List<string> roomTypeOptions = new()
+    {
+        "Banquet",
+        "Conference",
+        "Theatre",
+        "Classroom",
+        "U-Shape",
+        "Boardroom",
+        "Hollow Square",
+        "Crescent Rounds",
+        "Reception"
+    };
     string BasePath = @"/RFPResponsePOC";
 
     public class ProposalRow


### PR DESCRIPTION
## Summary
- Replace Room Type textbox with dropdown of allowed types
- Add list of standard room types for dropdown options

## Testing
- `dotnet build RFPPOC.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689fea5155348333864f8d6dfd0c1803