### PR TITLE
Add knowledgebase page with document embeddings

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Models/KnowledgeChunk.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Models/KnowledgeChunk.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace RFPResponsePOC.Client.Models
+{
+    public class KnowledgeChunk
+    {
+        public string Id { get; set; }
+        public string Content { get; set; }
+        public string Embedding { get; set; }
+    }
+}

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Home.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Home.razor
@@ -24,6 +24,7 @@
         <RadzenMenuItem Click="OnHomeClicked" Text="Home" Icon="home"></RadzenMenuItem>
         <RadzenMenuItem Click="OnCapacityClicked" Text="Capacity" Icon="aspect_ratio"></RadzenMenuItem>
         <RadzenMenuItem Click="OnProposalClicked" Text="Proposal" Icon="aspect_ratio"></RadzenMenuItem>
+        <RadzenMenuItem Click="OnKnowledgebaseClicked" Text="Knowledgebase" Icon="library_books"></RadzenMenuItem>
         <RadzenMenuItem Click="OnLogsClicked" Text="Logs" Icon="assignment"></RadzenMenuItem>
         <RadzenMenuItem Click="OnSettingsClicked" Text="Settings" Icon="line_style"></RadzenMenuItem>
     }
@@ -264,6 +265,11 @@ else
         CapacityVisible = false;
         ProposalVisible = true;
         LogsVisible = false;
+    }
+
+    void OnKnowledgebaseClicked(MenuItemEventArgs args)
+    {
+        Navigation.NavigateTo("/knowledgebase");
     }
 
     void PrposalClicked(MouseEventArgs args)

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
@@ -1,0 +1,140 @@
+@page "/knowledgebase"
+@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
+@using System.Text
+@using System.IO
+@using System.Collections.Generic
+@using System.Linq
+@using Newtonsoft.Json
+@using RFPResponsePOC.Client.Models
+@using RFPResponsePOC.Client.Services
+@using RFPResponsePOC.AI
+@using Microsoft.AspNetCore.Components.Forms
+@inject NotificationService NotificationService
+@inject LogService LogService
+@inject SettingsService _SettingsService
+@inject NavigationManager Navigation
+<h3>Knowledgebase</h3>
+<RadzenUpload @ref="uploader"
+              ChooseText="Upload document (.txt)" Accept=".txt"
+              Change=@OnFileUpload
+              Multiple="false"
+              Auto="true"
+              Style="width: 100%"
+              InputAttributes="@(new Dictionary<string,object>{{"aria-label","select file"}})">
+</RadzenUpload>
+<br />
+<RadzenButton Text="Add Row" Icon="add" Style="margin-bottom:10px" ButtonStyle="ButtonStyle.Primary" Click="InsertRow" />
+@if (entries?.Any() == true)
+{
+    <RadzenButton Text="Save Knowledgebase" Icon="save" Style="margin-left:10px;margin-bottom:10px;background-color:#007bff;" ButtonStyle="ButtonStyle.Primary" Click="SaveKnowledgebaseData" />
+    <RadzenDataGrid @ref="grid" Data="@entries" TItem="KnowledgeChunk" EditMode="DataGridEditMode.Single" AllowPaging="false">
+        <Columns>
+            <RadzenDataGridColumn TItem="KnowledgeChunk" Filterable="false" Sortable="false" Width="110px" TextAlign="TextAlign.Center" Title="EDIT/DEL">
+                <Template Context="chunk">
+                    @if (grid.IsRowInEditMode(chunk))
+                    {
+                        <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.ExtraSmall" Click="@(async args => await SaveRow(chunk))" @onclick:stopPropagation="true" />
+                        <span>&nbsp;</span>
+                        <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Size="ButtonSize.ExtraSmall" Click="@(async args => await DeleteRow(chunk))" @onclick:stopPropagation="true" />
+                    }
+                    else
+                    {
+                        <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.ExtraSmall" Click="@((args) => EditRow(chunk))" @onclick:stopPropagation="true" />
+                    }
+                </Template>
+            </RadzenDataGridColumn>
+            <RadzenDataGridColumn TItem="KnowledgeChunk" Property="Content" Title="Content">
+                <Template Context="chunk">
+                    <div style="white-space:pre-wrap">@chunk.Content</div>
+                </Template>
+                <EditTemplate Context="chunk">
+                    <RadzenTextArea @bind-Value="chunk.Content" Rows="3" Style="width:100%" />
+                </EditTemplate>
+            </RadzenDataGridColumn>
+        </Columns>
+    </RadzenDataGrid>
+}
+@code {
+    #nullable disable
+    string BasePath = @"/RFPResponsePOC";
+    Radzen.Blazor.RadzenUpload uploader;
+    Radzen.Blazor.RadzenDataGrid<KnowledgeChunk> grid;
+    List<KnowledgeChunk> entries = new();
+    OrchestratorMethods objOrchestratorMethods;
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            objOrchestratorMethods = new OrchestratorMethods(_SettingsService, LogService);
+            var json = await GetKnowledgebaseJsonAsync();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                entries = JsonConvert.DeserializeObject<List<KnowledgeChunk>>(json) ?? new();
+                StateHasChanged();
+            }
+        }
+    }
+    async Task OnFileUpload(UploadChangeEventArgs e)
+    {
+        var file = e.Files.FirstOrDefault();
+        if (file == null) return;
+        using var stream = file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+        using var reader = new StreamReader(stream);
+        var content = await reader.ReadToEndAsync();
+        var words = content.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < words.Length; i += 200)
+        {
+            var chunkWords = words.Skip(i).Take(200);
+            var chunkText = string.Join(" ", chunkWords);
+            var embedding = objOrchestratorMethods.GetVectorEmbedding(chunkText, false);
+            entries.Add(new KnowledgeChunk { Id = Guid.NewGuid().ToString(), Content = chunkText, Embedding = embedding });
+        }
+        await SaveKnowledgebaseData();
+        await uploader.ClearFiles();
+        NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Success, Summary = "Uploaded", Detail = "Document processed", Duration = 4000 });
+        StateHasChanged();
+    }
+    Task EditRow(KnowledgeChunk chunk) => grid.EditRow(chunk);
+    async Task SaveRow(KnowledgeChunk chunk)
+    {
+        chunk.Embedding = objOrchestratorMethods.GetVectorEmbedding(chunk.Content, false);
+        await grid.UpdateRow(chunk);
+        await SaveKnowledgebaseData();
+    }
+    async Task DeleteRow(KnowledgeChunk chunk)
+    {
+        if (entries.Contains(chunk))
+        {
+            entries.Remove(chunk);
+            await grid.Reload();
+            await SaveKnowledgebaseData();
+        }
+    }
+    async Task InsertRow()
+    {
+        var newChunk = new KnowledgeChunk { Id = Guid.NewGuid().ToString(), Content = string.Empty, Embedding = string.Empty };
+        entries.Add(newChunk);
+        await grid.Reload();
+        await grid.EditRow(newChunk);
+    }
+    async Task SaveKnowledgebaseData()
+    {
+        var json = JsonConvert.SerializeObject(entries, Formatting.Indented);
+        await File.WriteAllTextAsync($"{BasePath}//knowledgebase.json", json);
+    }
+    private async Task<string> GetKnowledgebaseJsonAsync()
+    {
+        try
+        {
+            if (File.Exists($"{BasePath}//knowledgebase.json"))
+            {
+                return await File.ReadAllTextAsync($"{BasePath}//knowledgebase.json");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error reading knowledgebase.json: {ex.Message}");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add Knowledgebase page with document upload, chunking, and embedding storage
- persist knowledgebase entries to JSON and allow add/edit/delete via DataGrid
- link new Knowledgebase page from home menu

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a09c653f9883338374c4d661c11155