### PR TITLE
Process all pages of uploaded PDFs

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
@@ -118,34 +118,45 @@
                 CurrentStatus = $"Reading File...";
                 StateHasChanged();
 
-                byte[] imageBytes;
+                var OCRprompt = await Http.GetStringAsync("Prompts/OCR.prompt");
+                var settingsService = new SettingsService();
 
                 if (file.ContentType == "application/pdf")
                 {
-                    var pdfUrl = await PdfService.GetPdfDataUrlAsync(file);
-                    if (pdfUrl == null) return;
-                    await PdfService.RenderPdfToCanvasAsync(pdfUrl, "pdfCanvas");
-                    imageBytes = await PdfService.GetCanvasPngBytesAsync("pdfCanvas");
+                    var pages = await PdfService.GetPdfPagesAsPngBytesAsync(file);
+                    for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++)
+                    {
+                        CurrentStatus = $"Processing page {pageIndex + 1} of {pages.Count}";
+                        StateHasChanged();
+
+                        var result = await objOrchestratorMethods.CallOpenAIFileAsync(settingsService, OCRprompt, pages[pageIndex]);
+
+                        if (!string.IsNullOrWhiteSpace(result.Error))
+                        {
+                            NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Error, Summary = "Error", Detail = result.Error, Duration = 4000 });
+                            return;
+                        }
+
+                        content += result.Response + " ";
+                    }
                 }
                 else
                 {
                     using var imgStream = file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
                     using var ms = new MemoryStream();
                     await imgStream.CopyToAsync(ms);
-                    imageBytes = ms.ToArray();
+                    var imageBytes = ms.ToArray();
+
+                    var result = await objOrchestratorMethods.CallOpenAIFileAsync(settingsService, OCRprompt, imageBytes);
+
+                    if (!string.IsNullOrWhiteSpace(result.Error))
+                    {
+                        NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Error, Summary = "Error", Detail = result.Error, Duration = 4000 });
+                        return;
+                    }
+
+                    content = result.Response;
                 }
-
-                var OCRprompt = await Http.GetStringAsync("Prompts/OCR.prompt");
-                var settingsService = new SettingsService();
-                var result = await objOrchestratorMethods.CallOpenAIFileAsync(settingsService, OCRprompt, imageBytes);
-
-                if (!string.IsNullOrWhiteSpace(result.Error))
-                {
-                    NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Error, Summary = "Error", Detail = result.Error, Duration = 4000 });
-                    return;
-                }
-
-                content = result.Response;
             }
             else
             {

--- a/RFPResponsePOC/RFPResponsePOC.Client/Services/PdfToPngService.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Services/PdfToPngService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.Forms;
 using System;
 using System.Threading.Tasks;
 using System.Text;
+using System.Collections.Generic;
 
 namespace BlazorWebAssemblyPDF.Services
 {
@@ -44,6 +45,20 @@ namespace BlazorWebAssemblyPDF.Services
             // dataUrl is like "data:image/png;base64,..."
             var base64 = dataUrl.Substring(dataUrl.IndexOf(",") + 1);
             return Convert.FromBase64String(base64);
+        }
+
+        public async Task<List<byte[]>> GetPdfPagesAsPngBytesAsync(IBrowserFile pdfFile)
+        {
+            var pdfDataUrl = await GetPdfDataUrlAsync(pdfFile);
+            if (pdfDataUrl == null) return new List<byte[]>();
+            var dataUrls = await _jsRuntime.InvokeAsync<string[]>("pdfInterop.getPdfPagesAsPng", pdfDataUrl);
+            var images = new List<byte[]>();
+            foreach (var dataUrl in dataUrls)
+            {
+                var base64 = dataUrl.Substring(dataUrl.IndexOf(",") + 1);
+                images.Add(Convert.FromBase64String(base64));
+            }
+            return images;
         }
 
         // SaveCanvasAsPngAsync can remain for download, but use GetCanvasPngBytesAsync for bytes

--- a/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
+++ b/RFPResponsePOC/RFPResponsePOC/wwwroot/js/pdfInterop.js
@@ -43,6 +43,31 @@ window.pdfInterop = {
         if (!canvas) return null;
         return canvas.toDataURL('image/png');
     },
+    getPdfPagesAsPng: async function (pdfUrl) {
+        if (!window.pdfjsLib) {
+            window.pdfjsLib = await import('https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.54/pdf.min.mjs');
+        }
+        window.pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.54/pdf.worker.min.mjs';
+
+        const loadingTask = window.pdfjsLib.getDocument({ url: pdfUrl });
+        const pdf = await loadingTask.promise;
+        const images = [];
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+        const scale = 2.0;
+
+        for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+            const page = await pdf.getPage(pageNumber);
+            const viewport = page.getViewport({ scale });
+            canvas.height = viewport.height;
+            canvas.width = viewport.width;
+            context.clearRect(0, 0, canvas.width, canvas.height);
+            await page.render({ canvasContext: context, viewport: viewport }).promise;
+            images.push(canvas.toDataURL('image/png'));
+        }
+
+        return images;
+    },
     exportElementToPdf: async function(elementId) {
         const element = document.getElementById(elementId);
         if (!element) {


### PR DESCRIPTION
## Summary
- Add JS utility to render every PDF page as PNG images
- Expose new PDF service method to retrieve PNG bytes for all pages
- Update knowledgebase upload logic to OCR each PDF page sequentially

## Testing
- ⚠️ `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e43330e083338c296cb6884c3fe4