### PR TITLE
Ensure Knowledgebase grid groups entries by title

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Knowledgebase.razor
@@ -290,8 +290,7 @@
 
     void OnGridRender(DataGridRenderEventArgs<KnowledgeChunk> args)
     {
-        if (args.FirstRender &&
-            !args.Grid.Groups.Any(g => g.Property == nameof(KnowledgeChunk.EntryTitle)))
+        if (args.FirstRender)
         {
             args.Grid.Groups.Add(new GroupDescriptor
             {


### PR DESCRIPTION
## Summary
- default Knowledgebase grid to group rows by `EntryTitle` on first render for consistent organization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a473fa77748333b96307d4af5a8cc5