### PR TITLE
Identify questions in RFP uploads

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
@@ -59,8 +59,14 @@
 <RadzenTabs RenderMode="TabRenderMode.Client">
     <Tabs>
         <RadzenTabsItem Text="Edit Response">
-            <p>In Progress...</p>
-            </RadzenTabsItem>
+            <div style="max-height:300px; overflow-y:auto;">
+                <RadzenDataGrid Data="@identifiedQuestions" TItem="string">
+                    <Columns>
+                        <RadzenDataGridColumn TItem="string" Property="." Title="Questions" />
+                    </Columns>
+                </RadzenDataGrid>
+            </div>
+        </RadzenTabsItem>
             @if (VenueTypeSelected)
             {
              <RadzenTabsItem Text="Venue Options">
@@ -212,6 +218,9 @@
 
     AIResponse result = new AIResponse();
     ZipService objZipService = new ZipService();
+
+    private List<string> identifiedQuestions = new();
+    private bool skipIdentifyQuestions = false;
 
     private List<ProposalRow> proposalRows = new();
     private List<string> roomOptions = new();
@@ -578,6 +587,38 @@
     public async Task HandleBeforeUnload() => await objZipService.ZipTheFiles();
     #endregion
 
+    private async Task<List<string>> IdentifyQuestions()
+    {
+        try
+        {
+            var prompt = await Http.GetStringAsync("Prompts/IdentifyQuestions.prompt");
+            prompt = prompt.Replace("{{RFPText}}", RFPText ?? string.Empty);
+
+            var objOrchestratorMethods = new OrchestratorMethods(_SettingsService, LogService);
+            var settingsService = new SettingsService();
+
+            var response = await objOrchestratorMethods.CallOpenAIAsync(settingsService, prompt);
+
+            if (string.IsNullOrWhiteSpace(response.Error))
+            {
+                identifiedQuestions = JsonConvert.DeserializeObject<List<string>>(response.Response) ?? new List<string>();
+            }
+            else
+            {
+                identifiedQuestions = new List<string>();
+                await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: IdentifyQuestions failed - {response.Error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            identifiedQuestions = new List<string>();
+            await LogService.WriteToLogAsync($"[{DateTime.Now}] ERROR: Exception in IdentifyQuestions - {ex.Message}");
+        }
+
+        StateHasChanged();
+        return identifiedQuestions;
+    }
+
     private async Task OnProposalUpload(UploadChangeEventArgs e)
     {
         try
@@ -680,6 +721,8 @@
 
             await uploader.ClearFiles();
 
+            await IdentifyQuestions();
+            skipIdentifyQuestions = true;
             await CreateProposal();
         }
         catch (Exception ex)
@@ -705,6 +748,12 @@
             InProgress = true;
             CurrentStatus = "Creating new proposal...";
             StateHasChanged();
+
+            if (!skipIdentifyQuestions)
+            {
+                await IdentifyQuestions();
+            }
+            skipIdentifyQuestions = false;
 
             NotificationService.Notify(new NotificationMessage
             {

--- a/RFPResponsePOC/RFPResponsePOC.Client/wwwroot/Prompts/IdentifyQuestions.prompt
+++ b/RFPResponsePOC/RFPResponsePOC.Client/wwwroot/Prompts/IdentifyQuestions.prompt
@@ -1,0 +1,12 @@
+Please review the following text and identify any questions it contains. Return only a JSON array of strings. If no questions are found, return an empty JSON array.
+
+### RFP TEXT START
+{{RFPText}}
+### RFP TEXT END
+
+### JSON FORMAT START
+[
+  "What is the budget?",
+  "Is catering required?"
+]
+### JSON FORMAT STOP


### PR DESCRIPTION
## Summary
- extract potential questions from RFP text via new `IdentifyQuestions` workflow
- store questions returned by LLM and show them in a Radzen grid under "Edit Response"
- add prompt file to instruct LLM to output only a JSON array of questions

## Testing
- `dotnet build` *(fails: compatible 9.0 SDK required)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c6c566c8333912cdc96a1256873