### PR TITLE
Answer RFP questions using knowledge base

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
@@ -991,6 +991,14 @@
             if (identifiedQuestions?.Any() == true)
             {
                 await LogService.WriteToLogAsync($"[{DateTime.Now}] CreateProposal: First few questions: {string.Join(", ", identifiedQuestions.Take(3).Select(q => q.Question))}");
+                var orchestrator = new OrchestratorMethods(_SettingsService, LogService);
+                var total = identifiedQuestions.Count;
+                for (int i = 0; i < identifiedQuestions.Count; i++)
+                {
+                    CurrentStatus = $"Answering question {i + 1} out of {total}...";
+                    StateHasChanged();
+                    await orchestrator.AnswerQuestionsFromKnowledgebase(identifiedQuestions[i], BasePath);
+                }
             }
 
             // Refresh QuestionGrid data grid if it's not null

--- a/RFPResponsePOC/RFPResponsePOC.Client/wwwroot/Prompts/AnswerQuestion.prompt
+++ b/RFPResponsePOC/RFPResponsePOC.Client/wwwroot/Prompts/AnswerQuestion.prompt
@@ -1,0 +1,9 @@
+Answer the question using only the information provided in the knowledge base.
+Return only a JSON object with a single property "answer".
+If the knowledge base does not contain the answer, return {"answer": ""}.
+
+### QUESTION
+{{Question}}
+
+### KNOWLEDGE BASE
+{{Knowledgebase}}


### PR DESCRIPTION
## Summary
- Process one question per call in knowledge-base answering routine
- Iterate through questions in `CreateProposal` while updating status per question

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5ea5e7bc8333b816d5b20b29f498