### PR TITLE
Use knowledgebase content for template tokens

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
@@ -1,5 +1,6 @@
 ﻿@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @using System.Text
+@using System.Text.RegularExpressions
 @using System.Collections.Generic
 @using System.Linq
 @using BlazorWebAssemblyPDF.Services
@@ -435,6 +436,26 @@
             if (templateContent.Contains("[PROPOSAL]", StringComparison.OrdinalIgnoreCase))
             {
                 templateContent = templateContent.Replace("[PROPOSAL]", proposalSummary);
+            }
+
+            // *********************************************
+            // Replace Knowledgebase tokens
+            // *********************************************
+            var kbJson = await KnowledgebaseService.GetKnowledgebaseJsonAsync();
+            if (!string.IsNullOrWhiteSpace(kbJson))
+            {
+                var kbEntries = JsonConvert.DeserializeObject<List<KnowledgeChunk>>(kbJson) ?? new List<KnowledgeChunk>();
+                var matches = Regex.Matches(templateContent, @"\[(.*?)\]");
+                foreach (Match match in matches.Cast<Match>())
+                {
+                    var token = match.Groups[1].Value;
+                    var entry = kbEntries.FirstOrDefault(e => e.EntryTitle == token);
+                    if (entry != null)
+                    {
+                        templateContent = templateContent.Replace($"[{token}]", entry.Content);
+                    }
+                }
+            }
             }
 
             // *********************************************


### PR DESCRIPTION
## Summary
- Detect tokens like `[TOKEN]` in response templates and swap them with matching knowledgebase entries
- Add regex support for token replacement in `Response.razor`

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.303)*

------
https://chatgpt.com/codex/tasks/task_e_68b62c82fe048333bb855272bb5d589d