### PR TITLE
Prompt for template tokens before generating response document

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Response.razor
@@ -486,6 +486,35 @@
             }
 
             // *********************************************
+            // Prompt for any remaining tokens
+            // *********************************************
+            var remainingTokens = Regex.Matches(templateContent, @"\[(.*?)\]")
+                .Cast<Match>()
+                .Select(m => m.Value)
+                .Where(t => !string.Equals(t, "[VENUE_PROPOSAL]", StringComparison.OrdinalIgnoreCase)
+                         && !string.Equals(t, "[VENUE_UNABLE_TO_ACCOMMODATE_AGENDA_ITEMS]", StringComparison.OrdinalIgnoreCase))
+                .Distinct()
+                .ToList();
+
+            if (remainingTokens.Any())
+            {
+                var result = await DialogService.OpenAsync<TokenInputDialog>(
+                    "Enter Values",
+                    new Dictionary<string, object> { { "Tokens", remainingTokens } });
+
+                if (result is Dictionary<string, string> values)
+                {
+                    foreach (var token in remainingTokens)
+                    {
+                        if (values.TryGetValue(token, out var value) && !string.IsNullOrWhiteSpace(value))
+                        {
+                            templateContent = templateContent.Replace(token, value);
+                        }
+                    }
+                }
+            }
+
+            // *********************************************
             // Generate Word Document
             // *********************************************
             using (var ms = new MemoryStream())

--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/TokenInputDialog.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/TokenInputDialog.razor
@@ -1,0 +1,35 @@
+@using Radzen
+@inject DialogService DialogService
+
+<RadzenTemplateForm Data="@TokenValues" TItem="Dictionary<string, string>" Submit="OnSubmit">
+    <ChildContent>
+        @foreach (var token in Tokens)
+        {
+            <RadzenLabel Text="@token" />
+            <RadzenTextBox @bind-Value="TokenValues[token]" Style="width:100%" Name="@token" />
+            <br />
+        }
+        <div style="margin-top:10px">
+            <RadzenButton Text="OK" ButtonType="ButtonType.Submit" Style="margin-right:5px" />
+            <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Secondary" Click="@(() => DialogService.Close(null))" />
+        </div>
+    </ChildContent>
+</RadzenTemplateForm>
+
+@code {
+    [Parameter] public List<string> Tokens { get; set; } = new();
+    private Dictionary<string, string> TokenValues = new();
+
+    protected override void OnInitialized()
+    {
+        foreach (var token in Tokens)
+        {
+            TokenValues[token] = string.Empty;
+        }
+    }
+
+    void OnSubmit(Dictionary<string, string> values)
+    {
+        DialogService.Close(TokenValues);
+    }
+}


### PR DESCRIPTION
## Summary
- Add TokenInputDialog to collect values for unfilled placeholders.
- Detect remaining [TOKEN]s in GenerateResponseDocument and prompt user to fill them before Word generation.

## Testing
- `dotnet build RFPResponsePOC/RFPResponsePOC.Client/RFPResponsePOC.Client.csproj`
- `dotnet build` *(fails: Could not copy apphost; destination is a folder)*

------
https://chatgpt.com/codex/tasks/task_e_68b65054dadc8333bbfef7aeb352d96d