### PR TITLE
Add persistent installation GUID and display on settings page

### DIFF
--- a/RFPResponsePOC/RFPResponsePOC.Client/Pages/Settings.razor
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Pages/Settings.razor
@@ -31,6 +31,10 @@
                 <RadzenDropDown @bind-Value="@AIModel" Data="@availableModels" Style="width: 450px;" TValue="string" />
             </RadzenFormField>
 
+            <RadzenFormField Text="Installation GUID:" Variant="@variant">
+                <RadzenTextBox Value="@GUID" Style="width:450px;" ReadOnly="true" />
+            </RadzenFormField>
+
             <div style="display: flex; justify-content: center; align-items: center; gap:10px;">
             @if (!IsOpenAISettingsEntered)
             {
@@ -124,6 +128,7 @@
     private string ApiKey = "";
     private string AIModel = "";
     private string AIEmbeddingModel = "";
+    private string GUID = "";
     private List<string> availableModels = new List<string> { "o4-mini", "gpt-4o", "gpt-5", "gpt-5-mini" };
 
     bool ZipFileExists = false;
@@ -150,6 +155,7 @@
 
             ApiKey = SettingsService.Settings.ApplicationSettings.ApiKey ?? "";
             AIModel = SettingsService.Settings.ApplicationSettings.AIModel;
+            GUID = SettingsService.Settings.ApplicationSettings.GUID;
 
             IsOpenAISettingsEntered = ApiKey.Length > 1;
 

--- a/RFPResponsePOC/RFPResponsePOC.Client/Services/SettingsService.cs
+++ b/RFPResponsePOC/RFPResponsePOC.Client/Services/SettingsService.cs
@@ -2,6 +2,7 @@ using Blazored.LocalStorage;
 using Newtonsoft.Json;
 using OpenAI.Files;
 using System.Text.Json.Serialization;
+using System;
 
 namespace RFPResponseAPP.Model
 {
@@ -13,6 +14,7 @@ namespace RFPResponseAPP.Model
             public string AIModel { get; set; }
             public string ApiKey { get; set; }
             public string AIEmbeddingModel { get; set; }
+            public string GUID { get; set; }
         }
 
         public enum ConnectionType
@@ -105,6 +107,13 @@ namespace RFPResponseAPP.Model
                 {
                     Settings.ConnectionSettings = new List<ConnectionSettings>();
                 }
+
+                // Ensure a GUID exists
+                if (string.IsNullOrEmpty(Settings.ApplicationSettings.GUID))
+                {
+                    Settings.ApplicationSettings.GUID = Guid.NewGuid().ToString();
+                    await SaveSettingsAsync();
+                }
             }
             catch (Exception ex)
             {
@@ -186,7 +195,8 @@ namespace RFPResponseAPP.Model
                     {
                         ApiKey = "",
                         AIModel = "gpt-5-mini",
-                        AIEmbeddingModel = "text-embedding-ada-002"
+                        AIEmbeddingModel = "text-embedding-ada-002",
+                        GUID = Guid.NewGuid().ToString()
                     },
                     ConnectionSettings = new List<ConnectionSettings>()
                 };

--- a/RFPResponsePOC/RFPResponsePOC/RFPResponsePOC/RFPResponsePOC.config
+++ b/RFPResponsePOC/RFPResponsePOC/RFPResponsePOC/RFPResponsePOC.config
@@ -2,6 +2,7 @@
   "ApplicationSettings": {
     "AIModel": "DefaultAIModel",
     "ApiKey": null,
+    "GUID": null,
     "AIType": "OpenAI",
     "Endpoint": "https://api.openai.com",
     "ApiVersion": "v1",


### PR DESCRIPTION
## Summary
- generate and persist a unique GUID in `SettingsService` on first launch
- surface the stored GUID on the Settings page in a read-only field for reference
- include GUID field in default configuration file

## Testing
- `$HOME/.dotnet/dotnet build RFPAPP.sln`
- `$HOME/.dotnet/dotnet test RFPAPP.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bf8f01285c83339020a7d5c6852fd1